### PR TITLE
fix(i18n): align superAdmin welcome message in ar.json

### DIFF
--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -100,7 +100,7 @@
   },
   "superAdmin": {
     "title": "لوحة تحكم المدير العام",
-    "welcome": "مرحباً {{name}} - إدارة المطاعم والحسابات",
+    "welcome": "مرحباً {{name}}",
     "stats": {
       "totalRestaurants": "إجمالي المطاعم",
       "activeCount": "{{count}} نشط",

--- a/tests/i18n-key-parity.spec.ts
+++ b/tests/i18n-key-parity.spec.ts
@@ -81,4 +81,11 @@ test.describe('i18n Key Parity Verification', () => {
 
     expect(mismatches, `Found ${mismatches.length} placeholder mismatches:\n${mismatches.slice(0, 5).join('\n')}${mismatches.length > 5 ? '\n...' : ''}`).toEqual([]);
   });
+
+  test('superAdmin.welcome key should have consistent greeting', () => {
+    const enWelcome = en.superAdmin.welcome;
+    const arWelcome = ar.superAdmin.welcome;
+    expect(arWelcome).toEqual('مرحباً {{name}}');
+    expect(enWelcome).toEqual('Welcome {{name}}');
+  });
 });


### PR DESCRIPTION
The Arabic translation for the `superAdmin.welcome` key contained additional text ("- إدارة المطاعم والحسابات") that was not present in the English version. This caused an inconsistent UI experience.

This commit removes the extra text from the Arabic translation to make it consistent with the English key.

A new test case has been added to `tests/i18n-key-parity.spec.ts` to verify the consistency of this specific key and prevent future regressions.