### PR TITLE
fix: Use valid status 'new' for orders from public menu

### DIFF
--- a/src/components/pos/POSDashboard.tsx
+++ b/src/components/pos/POSDashboard.tsx
@@ -210,8 +210,6 @@ export const POSDashboard: React.FC = () => {
           filter: `tenant_id=eq.${tenantId}`
         },
         (payload) => {
-          console.log('POS Order change:', payload);
-          
           if (payload.eventType === 'INSERT') {
             const newOrder = payload.new as POSOrder;
             setOrders(prev => [newOrder, ...prev]);

--- a/src/pages/PublicMenu.tsx
+++ b/src/pages/PublicMenu.tsx
@@ -373,7 +373,7 @@ const PublicMenu = (): JSX.Element => {
         const posOrderData = {
           tenant_id: tenant.id,
           order_number: orderNumber,
-          status: 'pending_approval', // All orders need approval first
+          status: 'new', // All orders need approval first
           items: cart as any, // Convert to JSON
           customer_info: finalCustomerInfo as any, // Convert to JSON
           total_amount: finalTotal,

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Orders created from the public menu were failing to be inserted into the `pos_orders` table due to a database check constraint violation. The status 'pending_approval' is not a valid status in the database schema.

This change updates the order creation logic in `PublicMenu.tsx` to use the valid status 'new' for all new orders. This allows orders to be created successfully and appear in the POS dashboard.

This is a temporary workaround for a broken "pending approval" workflow at the database level. A more complete fix would involve fixing the database migrations.